### PR TITLE
項目一覧ページ実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "java.compile.nullAnalysis.mode": "automatic",
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "livePreview.defaultPreviewPath": "/src/main/resources/templates/skills.html"
 }

--- a/src/main/java/com/spring/springbootapplication/controller/SkillController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/SkillController.java
@@ -1,0 +1,48 @@
+package com.spring.springbootapplication.controller;
+
+import com.spring.springbootapplication.dto.SkillDTO;
+import com.spring.springbootapplication.service.SkillService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Controller
+public class SkillController {
+
+    private final SkillService skillService;
+
+    public SkillController(SkillService skillService) {
+        this.skillService = skillService;
+    }
+
+    @GetMapping("/skills")
+    public String showSkills(@RequestParam(value = "month", required = false) String month,Model model) {
+
+        // デバック用
+        System.out.println("取得した month パラメータ: " + month);
+
+        // デフォルトは当月
+        if (month == null || month.isEmpty()) {
+            month = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+        }
+
+        // ダミーデータの取得
+        List<SkillDTO> backendSkills = skillService.getSkillsForCategory("バックエンド", month);
+        List<SkillDTO> frontendSkills = skillService.getSkillsForCategory("フロントエンド", month);
+        List<SkillDTO> infraSkills = skillService.getSkillsForCategory("インフラ", month);
+
+        // モデルに追加
+        model.addAttribute("currentMonth", month);
+        model.addAttribute("backendSkills", backendSkills);
+        model.addAttribute("frontendSkills", frontendSkills);
+        model.addAttribute("infraSkills", infraSkills);
+        model.addAttribute("pastMonths", skillService.getPastThreeMonths());
+
+        return "skills";
+    }
+}

--- a/src/main/java/com/spring/springbootapplication/dto/SkillDTO.java
+++ b/src/main/java/com/spring/springbootapplication/dto/SkillDTO.java
@@ -1,0 +1,31 @@
+package com.spring.springbootapplication.dto;
+
+public class SkillDTO {
+    private String category;
+    private String skillName;
+    private int learningHours;
+    private String month;
+
+    public SkillDTO(String category, String skillName, int learningHours, String month) {
+        this.category = category;
+        this.skillName = skillName;
+        this.learningHours = learningHours;
+        this.month = month;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getSkillName() {
+        return skillName;
+    }
+
+    public int getLearningHours() {
+        return learningHours;
+    }
+
+    public String getMonth() {
+        return month;
+    }
+}

--- a/src/main/java/com/spring/springbootapplication/service/SkillService.java
+++ b/src/main/java/com/spring/springbootapplication/service/SkillService.java
@@ -1,0 +1,71 @@
+package com.spring.springbootapplication.service;
+
+import com.spring.springbootapplication.dto.SkillDTO;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class SkillService {
+
+    public List<SkillDTO> getSkillsForCategory(String category, String month) {
+        List<SkillDTO> allSkills = createDummySkills();
+        return allSkills.stream()
+                .filter(skill -> skill.getCategory().equals(category) && skill.getMonth().equals(month))
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getPastThreeMonths() {
+        List<String> pastMonths = new ArrayList<>();
+        LocalDate now = LocalDate.now();
+        DateTimeFormatter dbFormat = DateTimeFormatter.ofPattern("yyyy-MM");
+        DateTimeFormatter displayFormat = DateTimeFormatter.ofPattern("M月");
+    
+        for (int i = 0; i < 3; i++) { // 当月 + 過去2ヶ月
+            String dbMonth = now.minusMonths(i).format(dbFormat);
+            String displayMonth = now.minusMonths(i).format(displayFormat);
+            pastMonths.add(dbMonth + "," + displayMonth); // "2025-01,1月" のようにセット
+        }
+        return pastMonths;
+    }
+
+    private List<SkillDTO> createDummySkills() {
+        List<SkillDTO> skills = new ArrayList<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+    
+        LocalDate now = LocalDate.now();
+        String currentMonth = now.format(formatter);
+        String lastMonth = now.minusMonths(1).format(formatter);
+        String twoMonthsAgo = now.minusMonths(2).format(formatter);
+    
+        // 当月データ
+        skills.add(new SkillDTO("バックエンド", "Java", 10, currentMonth));
+        skills.add(new SkillDTO("バックエンド", "Spring Boot", 10, currentMonth));
+        skills.add(new SkillDTO("バックエンド", "Ruby", 10, currentMonth));
+        skills.add(new SkillDTO("バックエンド", "PHP", 10, currentMonth));
+        skills.add(new SkillDTO("フロントエンド", "React", 10, currentMonth));
+        skills.add(new SkillDTO("フロントエンド", "Vue.js", 10, currentMonth));
+        skills.add(new SkillDTO("インフラ", "AWS", 10, currentMonth));
+    
+        // 先月データ
+        skills.add(new SkillDTO("バックエンド", "Java", 20, lastMonth));
+        skills.add(new SkillDTO("バックエンド", "Spring Boot", 20, lastMonth));
+        skills.add(new SkillDTO("フロントエンド", "React", 20, lastMonth));
+        skills.add(new SkillDTO("フロントエンド", "Vue.js", 20, lastMonth));
+        skills.add(new SkillDTO("インフラ", "AWS", 20, lastMonth));
+    
+        // 2ヶ月前データ
+        skills.add(new SkillDTO("バックエンド", "Java", 30, twoMonthsAgo));
+        skills.add(new SkillDTO("バックエンド", "Spring Boot", 30, twoMonthsAgo));
+        skills.add(new SkillDTO("フロントエンド", "React", 30, twoMonthsAgo));
+        skills.add(new SkillDTO("フロントエンド", "Vue.js", 30, twoMonthsAgo));
+        skills.add(new SkillDTO("インフラ", "AWS", 30, twoMonthsAgo));
+    
+        return skills;
+    }
+    
+}

--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -85,3 +85,29 @@
 .submit-btn {
     margin: 0; 
 }
+
+.learning-chart-section {
+    text-align: center;
+    margin-top: 100px;
+}
+
+.chart-title {
+    font-size: 36px;
+    font-weight: 700;
+    position: relative;
+}
+
+/* 学習チャートの下線 */
+.chart-title::after {
+    content: "";
+    display: block;
+    width: 400px;
+    height: 2px;
+    background-color: #000000BF;
+    margin: 8px auto 40px;
+}
+
+.submit-btn.small-btn {
+    width: 152px;
+    margin: 0 auto ; 
+}

--- a/src/main/resources/static/css/skills.css
+++ b/src/main/resources/static/css/skills.css
@@ -1,0 +1,151 @@
+@import url('/css/common.css');
+
+.skills-header {
+    display: flex;
+    width: 960px;
+    margin: 40px auto;
+}
+
+/* 月選択プルダウン */
+.month-dropdown {
+    width: 94px;
+    height: 44px;
+    font-size: 24px;
+    font-weight: 700;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    padding: 5px;
+    text-align: center;
+}
+
+.skills-container {
+    width: 960px;
+    margin: 0 auto;
+}
+
+.category-box {
+    width: 960px;
+    height: 436px;
+    border-radius: 8px;
+    border: 1px solid #00000080;
+    padding: 40px;
+    margin-bottom: 40px;
+}
+
+.category-header {
+    display: flex ;
+    justify-content: space-between;
+    align-items: center;
+    width: 880px;  
+    margin-bottom: 30px;
+}
+
+.category-title {
+    font-size: 24px;
+    font-weight: 700;
+    width: 880px;
+    flex-grow: 1; 
+    position: relative;
+}
+    .category-title:after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -10px; 
+    width: 240px; 
+    height: 2px;
+    background-color: #000000BF; 
+} 
+
+.submit-btn.skill-edit-btn {
+    width: 178px;
+    font-size: 14px;
+    margin-left: auto;
+    display: flex;
+    justify-content: center;
+}
+
+
+.skills-list {
+    width: 880px;
+    height: 276px;
+    overflow-y: auto;
+    margin: 10px auto;
+    border-radius: 4px;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+/* ヘッダーを固定 */
+thead {
+    position: sticky;
+    top: 0;
+    background: white;
+    z-index: 2;
+}
+
+th, td {
+    height: 72px;
+    padding: 8px;
+    text-align: center;
+    border-bottom: 1px solid #ccc;
+    width: 25%;
+    font-size: 14px;
+}
+
+th {
+    height: 57px;
+    font-weight: 400;
+}
+
+th:first-of-type {
+    text-align: start;
+    padding-left: 50px;
+}
+
+td:first-of-type {
+    text-align: start;
+    padding-left: 50px;
+}
+
+th:nth-of-type(2) {
+    text-align: start;
+}
+
+td:nth-of-type(2) {
+    text-align: start;
+}
+
+.learning-hours-input {
+    width: 160px;
+    height: 40px;
+    font-size: 14px;
+    padding: 10px 12px;
+}
+
+.submit-btn.small-btn {
+    width: 100px;
+    font-size: 14px;
+    width: 158px;
+    height: 32px;
+    color: #1B5678;
+    border: 1px solid #1B5678;
+    background-color: #FFFFFF;
+    border-radius: 4px;
+}
+
+.delete-btn {
+    width: 100px;
+    font-size: 14px;
+    width: 88px;
+    height: 32px;
+    background-color: #EE6969;
+    color: white;
+    border: none;
+    cursor: pointer;
+    border-radius: 4px;
+}

--- a/src/main/resources/static/js/skills.js
+++ b/src/main/resources/static/js/skills.js
@@ -1,0 +1,9 @@
+document.addEventListener("DOMContentLoaded", function() {
+    
+    const monthSelect = document.getElementById("month-select");
+
+    monthSelect.addEventListener("change", function() {
+        const selectedMonth = this.value;
+        window.location.href = `/skills?month=${selectedMonth}`;
+    });
+});

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -7,7 +7,7 @@
     <title>ホームページ</title>
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/common.css"> 
-    <link rel="stylesheet" href="css/home.css">
+    <link rel="stylesheet" href="/css/home.css">
 </head>
 
 <body>
@@ -41,6 +41,14 @@
                     <a href="/profile/edit" class="submit-btn">自己紹介を編集する</a>
                 </div>
             </div>
+
+            <!-- 学習チャートセクション -->
+            <div class="learning-chart-section">
+                <h2 class="chart-title">学習チャート</h2>
+
+                <a href="/skills" class="submit-btn small-btn">編集する</a>
+            </div>
+
         </div>
 
         <footer class="footer">

--- a/src/main/resources/templates/skills.html
+++ b/src/main/resources/templates/skills.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>学習スキル一覧</title>
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/skills.css">
+</head>
+
+<body>
+    <div class="wrapper">
+
+        <header class="header">
+            <div class="header-logo">My Portfolio</div>
+            <form th:action="@{/auth/logout}" method="post" class="logout-form">
+                <button type="submit" class="btn logout-btn">ログアウト</button>
+            </form>
+        </header>
+
+        <div class="main-content">
+            <!-- 上部エリア -->
+            <div class="skills-header">
+
+                <!-- プルダウン選択 -->
+                <select id="month-select" class="month-dropdown" onchange="changeMonth()">
+                    <option th:each="month : ${pastMonths}"
+                            th:value="${#strings.arraySplit(month, ',')[0]}" 
+                            th:text="${#strings.arraySplit(month, ',')[1]}"
+                            th:selected="${#strings.arraySplit(month, ',')[0] == currentMonth}">
+                    </option>
+                </select>
+            </div>
+
+            <!-- スキルカテゴリごとのボックス -->
+            <div class="skills-container">
+
+                <!-- バックエンド -->
+                <div class="category-box">
+                    <div class="category-header">
+                        <h2 class="category-title">バックエンド</h2>
+                        <a href="/skills/new" class="submit-btn skill-edit-btn">項目を追加する</a>
+                    </div>
+                    <div class="skills-list">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>項目名</th>
+                                    <th>学習時間</th>
+                                    <th></th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr th:each="skill : ${backendSkills}">
+                                    <td th:text="${skill.skillName}">Spring Boot</td>
+                                    <td><input type="number" min="0" class="learning-hours-input" th:value="${skill.learningHours}"></td>
+                                    <td><button class="submit-btn small-btn">学習時間を保存する</button></td>
+                                    <td><button class="delete-btn">削除する</button></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <!-- フロントエンド -->
+                <div class="category-box">
+                    <div class="category-header">
+                        <h2 class="category-title">フロントエンド</h2>
+                        <a href="/skills/new" class="submit-btn skill-edit-btn">項目を追加する</a>
+                    </div>
+                    <div class="skills-list">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>項目名</th>
+                                    <th>学習時間</th>
+                                    <th></th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr th:each="skill : ${frontendSkills}">
+                                    <td th:text="${skill.skillName}">React</td>
+                                    <td><input type="number" min="0" class="learning-hours-input" th:value="${skill.learningHours}"></td>
+                                    <td><button class="submit-btn small-btn">学習時間を保存する</button></td>
+                                    <td><button class="delete-btn">削除する</button></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <!-- インフラ -->
+                <div class="category-box">
+                    <div class="category-header">
+                        <h2 class="category-title">インフラ</h2>
+                        <a href="/skills/new" class="submit-btn skill-edit-btn">項目を追加する</a>
+                    </div>
+                    <div class="skills-list">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>項目名</th>
+                                    <th>学習時間</th>
+                                    <th></th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr th:each="skill : ${infraSkills}">
+                                    <td th:text="${skill.skillName}">AWS</td>
+                                    <td><input type="number" min="0" class="learning-hours-input" th:value="${skill.learningHours}"></td>
+                                    <td><button class="submit-btn small-btn">学習時間を保存する</button></td>
+                                    <td><button class="delete-btn">削除する</button></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+
+        <footer class="footer">
+            <span class="footer-text">portfolio site</span>
+        </footer>
+    </div>
+
+    <script src="/js/skills.js"></script>
+
+</body>
+
+</html>


### PR DESCRIPTION
**実装内容**
- 一番最初に表示する際は当月のデータが表示される
- 月のデータは当月を含み過去3ヶ月分をプルダウンでそれぞれ選択できる
- プルダウンで選択後、その選択した月のデータが表示される
- 学習時間が3つ以上の場合は、スキルテーブル内でスクロールさせる

**実装後の結果**
Slackに動作確認動画を添付いたしました。

**備考・注意点**
- 今回は項目一覧ページの実装のみなので、ダミーデータを用意し、プルダウンから各月の該当ダミーデータが表示されるよう設定しています。今後の実装でDBの用意をしていく予定です。