### PR TITLE
項目追加機能実装

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/SkillNewController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/SkillNewController.java
@@ -88,7 +88,10 @@ public class SkillNewController {
         if (!isSuccess) {
             result.rejectValue("skillName", "error.skillName",
                     skillNewDTO.getSkillName() + " は既に登録されています");
+            
             model.addAttribute("categoryName", skillNewDTO.getCategoryName());
+            model.addAttribute("recordedMonth", skillNewDTO.getRecordedMonth().format(DateTimeFormatter.ofPattern("yyyy-MM")));
+            model.addAttribute("categoryId", skillNewDTO.getCategoryId());
             return "skills-new";
         }
 

--- a/src/main/java/com/spring/springbootapplication/dto/SkillNewDTO.java
+++ b/src/main/java/com/spring/springbootapplication/dto/SkillNewDTO.java
@@ -19,7 +19,7 @@ public class SkillNewDTO {
 
     @NotNull(message = "学習時間は必ず入力してください")
     @Min(value = 0, message = "学習時間は0以上の数字で入力してください")
-    private Integer learningHours;  // 学習時間（0以上の整数）
+    private Integer learningHours;  // 学習時間
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @NotNull(message = "実施月は必ず入力してください")


### PR DESCRIPTION
**実装内容**
- 項目名、学習時間をプルダウンで選択している月のデータとして登録できる
- 指定のバリデーションメッセージが表示される
- 正しくDBに保存され、登録できたら、[登録完了モーダル]を表示する
- モーダルの「編集ページに戻る」を押下すると[項目一覧画面]に遷移する

**実装後の結果**
- Slackに動作確認動画を添付いたしました。