### PR TITLE
項目追加機能実装 バリデーション修正

### DIFF
--- a/src/main/java/com/spring/springbootapplication/repository/LearningDataRepository.java
+++ b/src/main/java/com/spring/springbootapplication/repository/LearningDataRepository.java
@@ -13,9 +13,8 @@ import java.util.List;
 public interface LearningDataRepository extends JpaRepository<LearningDataEntity, Integer> {
 
     // 学習データの重複チェック 同一ユーザー、カテゴリ、月、スキル名が既に存在するか確認
-    Optional<LearningDataEntity> findByUser_IdAndCategory_IdAndRecordedMonthAndSkillName(
+    Optional<LearningDataEntity> findByUser_IdAndRecordedMonthAndSkillName(
             Long userId,
-            Integer categoryId,
             LocalDate recordedMonth,
             String skillName
     );

--- a/src/main/java/com/spring/springbootapplication/service/SkillNewService.java
+++ b/src/main/java/com/spring/springbootapplication/service/SkillNewService.java
@@ -38,9 +38,8 @@ public class SkillNewService {
 
         // 既存のスキルが存在するかチェック
         Optional<LearningDataEntity> existingSkill = learningDataRepository
-                .findByUser_IdAndCategory_IdAndRecordedMonthAndSkillName(
+                    .findByUser_IdAndRecordedMonthAndSkillName(
                         skillNewDTO.getUserId(),
-                        skillNewDTO.getCategoryId(),
                         skillNewDTO.getRecordedMonth(),
                         skillNewDTO.getSkillName()
                 );


### PR DESCRIPTION
**実装内容**
- 同じ月内である場合、項目名がカテゴリに関係なく重複しない。

**実装後の結果**
Slackに動作確認動画を添付いたしました。

**備考・注意点**
user_id、category_id、recorded_month、skill_name で重複チェックをしていましたが、category_id を外すことで、同じ月内でカテゴリに関係なくチェックする仕様に変更しました。