### PR TITLE
スキルチャート表示実装

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/SkillChartController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/SkillChartController.java
@@ -1,0 +1,30 @@
+package com.spring.springbootapplication.controller;
+
+import com.spring.springbootapplication.entity.UserEntity;
+import com.spring.springbootapplication.service.SkillService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/skills")
+public class SkillChartController {
+
+    private final SkillService skillService;
+
+    public SkillChartController(SkillService skillService) {
+        this.skillService = skillService;
+    }
+
+    @GetMapping("/chart-data")
+    public Map<String, Map<String, Integer>> getSkillChartData(@AuthenticationPrincipal UserEntity user) {
+        if (user == null) {
+            throw new IllegalStateException("ユーザー情報が取得できません。ログイン状態を確認してください。");
+        }
+
+        return skillService.getSkillChartData(user.getId());
+    }
+}

--- a/src/main/java/com/spring/springbootapplication/controller/SkillController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/SkillController.java
@@ -106,4 +106,3 @@ public class SkillController {
     }
 
 }
-

--- a/src/main/java/com/spring/springbootapplication/repository/LearningDataRepository.java
+++ b/src/main/java/com/spring/springbootapplication/repository/LearningDataRepository.java
@@ -32,4 +32,12 @@ public interface LearningDataRepository extends JpaRepository<LearningDataEntity
 
         // 削除処理
         void deleteByIdAndUser_Id(Long id, Long userId);
+
+        // カテゴリごとの各月の合計学習時間を取得
+        List<LearningDataEntity> findByUser_IdAndRecordedMonthBetween(
+                Long userId,
+                LocalDate startDate,
+                LocalDate endDate
+        );
+
 }

--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -88,7 +88,7 @@
 
 .learning-chart-section {
     text-align: center;
-    margin-top: 100px;
+    margin-top: 60px;
 }
 
 .chart-title {
@@ -111,3 +111,15 @@
     width: 152px;
     margin: 0 auto ; 
 }
+
+/* チャート */
+.chart-container {
+    width: 1000px;
+    height: 530px;
+    margin: 20px auto;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 80px;
+}
+

--- a/src/main/resources/static/js/home.js
+++ b/src/main/resources/static/js/home.js
@@ -1,0 +1,101 @@
+document.addEventListener("DOMContentLoaded", function () {
+    // APIエンドポイント
+    const apiUrl = "/api/skills/chart-data";
+
+    // グラフを描画する関数
+    function drawChart(chartData) {
+        const ctx = document.getElementById("learningChart").getContext("2d");
+
+        let months = Object.keys(chartData).sort(); // 昇順ソート
+
+        // 左から "先々月", "先月", "今月"に順番に変換
+        months = months.slice(-3); // 直近3ヶ月のみ使用
+
+        // ラベル変換（"先々月", "先月", "今月"）
+        const monthLabels = ["先々月", "先月", "今月"];
+
+        // カテゴリー別に配色
+        const categoryColors = {
+            "バックエンド": "rgba(255, 120, 150, 0.6)",
+            "フロントエンド": "rgba(255, 200, 100, 0.5)", 
+            "インフラ": "rgba(255, 240, 160, 0.7)" 
+        };
+
+        // データセットの準備
+        const datasets = [];
+
+        Object.keys(categoryColors).forEach(category => {
+            datasets.push({
+                label: category,
+                data: months.map(month => chartData[month]?.[category] || 0), 
+                backgroundColor: categoryColors[category],
+                borderColor: categoryColors[category].replace("0.7", "1"),
+                borderWidth: 1,
+            });
+        });
+
+        // 最大学習時間を計算（最小100、最大データ値の上限に設定）
+        const maxHours = Math.max(100, ...datasets.flatMap(dataset => dataset.data));
+
+        // Chart.jsの設定
+        new Chart(ctx, {
+            type: "bar",
+            data: {
+                labels: monthLabels, // 先々月・先月・今月
+                datasets: datasets
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        min: 0,
+                        max: maxHours,
+                        ticks: {
+                            font: {
+                                size: 14
+                            }
+                        },
+                        grid: {
+                            drawBorder: false
+                        }
+                    },
+                    x: {
+                        ticks: {
+                            font: {
+                                size: 14
+                            }
+                        },
+                        grid: {
+                            drawBorder: false
+                        },
+                    }
+                },
+                plugins: {
+                    legend: {
+                        position: "top",
+                        labels: {
+                            font: {
+                                size: 14
+                            }
+                        }
+                    },
+                    tooltip: {
+                        mode: "index",
+                        intersect: false
+                    }
+                }
+            }
+        });
+    }
+
+    // APIからデータを取得してグラフを描画
+    fetch(apiUrl)
+        .then(response => response.json())
+        .then(data => {
+            console.log("Chart Data:", data); // デバッグ用
+            drawChart(data);
+        })
+        .catch(error => console.error("Error loading chart data:", error));
+});

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -8,6 +8,8 @@
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/common.css"> 
     <link rel="stylesheet" href="/css/home.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script defer src="/js/home.js"></script>
 </head>
 
 <body>
@@ -47,6 +49,11 @@
                 <h2 class="chart-title">学習チャート</h2>
 
                 <a href="/skills" class="submit-btn small-btn">編集する</a>
+            </div>
+
+            <!-- グラフエリア -->
+            <div class="chart-container">
+                <canvas id="learningChart"></canvas>
             </div>
 
         </div>


### PR DESCRIPTION
**実装内容**
- Chart.jsを使用してチャートを実装
- バックエンド、フロントエンド、インフラで登録した項目の学習時間がチャートとして表示される
- 棒グラフのYは可変にし、最低100までは必ず表示する
- 削除された項目の時間は含まない

**実装後の結果**
Slackに動作確認動画を添付いたしました。

**備考・注意点**
figmaに各棒グラフの色の指定がありませんでしたので、近しい色のものを選択して実装しています。