### PR TITLE
自己紹介画像アップロード修正

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/ProfileController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/ProfileController.java
@@ -54,13 +54,19 @@ public class ProfileController {
     @PostMapping("/edit")
     public String updateProfile(@AuthenticationPrincipal UserDetails userDetails,
                                 @Valid @ModelAttribute("profileEditDTO") ProfileEditDTO profileEditDTO,
-                                BindingResult result) {
+                                BindingResult result, Model model) {
         
         if (userDetails == null) {
             return "redirect:/auth/login";
         }
 
+        // 画像サイズバリデーション（サーバー側）
+        if (!profileEditDTO.isValidImageSize()) {
+            result.rejectValue("image", "error.image", "ファイルサイズが上限を超えています。5MB以下のファイルを選択してください。");
+        } 
+
         if (result.hasErrors()) {
+            model.addAttribute("profileEditDTO", profileEditDTO);
             return "profile-edit";
         }
 
@@ -73,6 +79,7 @@ public class ProfileController {
         // 画像ファイルの更新処理
         MultipartFile imageFile = profileEditDTO.getImage();
         if (imageFile != null && !imageFile.isEmpty()) {
+            
             try {
                 byte[] imageBytes = imageFile.getBytes();
                 userService.updateUserProfileImage(user.getId(), imageBytes);

--- a/src/main/java/com/spring/springbootapplication/dto/ProfileEditDTO.java
+++ b/src/main/java/com/spring/springbootapplication/dto/ProfileEditDTO.java
@@ -11,6 +11,10 @@ public class ProfileEditDTO {
 
     private MultipartFile image;  // アップロードされるプロフィール画像
 
+    // 画像のバリデーション（ファイルサイズ5MB以下）
+    public boolean isValidImageSize() {
+        return (image == null || image.getSize() <= 5 * 1024 * 1024);
+    }
 
     // Getter & Setter
     public String getBio() {
@@ -28,4 +32,5 @@ public class ProfileEditDTO {
     public void setImage(MultipartFile image) {
         this.image = image;
     }
+
 }

--- a/src/main/resources/static/css/profile-edit.css
+++ b/src/main/resources/static/css/profile-edit.css
@@ -14,13 +14,14 @@
     text-align: center;
     border: none;
     padding: 8px 24px;
+    margin-top: 10px;
 }
 
 .upload-section {
     display: flex;
     align-items: center;
     flex-wrap: wrap; 
-    gap: 25px;
+    /* gap: 25px; */
 }
 
 
@@ -39,9 +40,9 @@
     white-space: normal; 
     display: flex;
     align-items: center;
+    margin-left: 20px;
 }
 
 .submit-btn {
     width: 322px;
 }
-

--- a/src/main/resources/static/js/profile-edit.js
+++ b/src/main/resources/static/js/profile-edit.js
@@ -1,10 +1,26 @@
 document.addEventListener("DOMContentLoaded", function () {
-    document.getElementById('image').addEventListener('change', function () {
-        const fileNameSpan = document.getElementById('file-name');
+    const fileInput = document.getElementById('image');
+    const fileNameSpan = document.getElementById('file-name');
+    const errorSpan = document.createElement("div"); // エラーメッセージ表示用
+    errorSpan.classList.add("text-danger");
+    fileInput.parentNode.appendChild(errorSpan); 
+
+    fileInput.addEventListener('change', function () {
+        errorSpan.textContent = ""; 
+        fileNameSpan.textContent = ""; 
+
         if (this.files.length > 0) {
-            fileNameSpan.textContent = this.files[0].name;
-        } else {
-            fileNameSpan.textContent = '';
+            const file = this.files[0];
+
+            // 5MB (5 * 1024 * 1024 = 5242880 bytes) を超えていないかチェック
+            if (file.size > 5242880) {
+                errorSpan.textContent = "ファイルサイズが上限を超えています。5MB以下のファイルを選択してください。";
+                fileInput.value = ""; 
+                return;
+            }
+
+            fileNameSpan.textContent = file.name; // ファイル名を表示
         }
     });
 });
+

--- a/src/main/resources/templates/profile-edit.html
+++ b/src/main/resources/templates/profile-edit.html
@@ -39,7 +39,11 @@
                             <label for="image" class="custom-file-upload">画像ファイルを添付する</label>
                             <input type="file" id="image" name="image" class="form-control-file">
                             <span id="file-name" class="text-info"></span>
+                            <div class="text-danger" th:if="${#fields.hasErrors('image')}" th:errors="*{image}">
+                                ファイルサイズが上限を超えています。5MB以下のファイルを選択してください。
+                            </div>
                         </div>
+                        
                     </div>
 
                     <button type="submit" class="submit-btn">自己紹介を確定する</button>


### PR DESCRIPTION
**エラー内容**
- 1MB以上のサイズの画像アップロードができない

**実装内容**
- 5MBまでの画像ファイルサイズのアップロードを拡張し、それ以上のファイルサイズはバリデーションメッセージで制御する

**実装後**
- 5MBまでのファイルサイズはアップロードができ、それ以上のサイズのアップロードされた場合は「ファイルサイズが上限を超えています。5MB以下のファイルを選択してください。」とバリデーションメッセージが入るよう実装しました。